### PR TITLE
Add new configuration option for keeping preferences

### DIFF
--- a/src/main/java/com/rolerandomizer/RoleRandomizerConfig.java
+++ b/src/main/java/com/rolerandomizer/RoleRandomizerConfig.java
@@ -40,4 +40,14 @@ public interface RoleRandomizerConfig extends Config
     {
         return false;
     }
+    
+    @ConfigItem(
+            keyName = "keepPreviousPreferences",
+            name = "Keep role preferences ticked",
+            description = "Keep role preferences ticked after the randomize button has been pressed"
+    }
+    default boolean keepPreferences()
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
Currently the way the UI randomizer works is it removes the roles after the 'randomize' button has been pressed.

This change will allow preferences to be saved, probably for longer runs. However this also means some players will get the same role multiple times in a row, maybe there should be some other logic for it?